### PR TITLE
Add Corporate Emissions section with Carbon3 Registry data

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Before proposing changes, please read the `CONTRIBUTING.MD` to understand in mor
 * [London Data Store Environmental topic](https://data.london.gov.uk/dataset?topics=fb70a4e6-311c-41c1-8429-3fe27ebc928a)
 * [DataHub climate change collection](https://datahub.io/collections/climate-change)
 
+### Corporate Emissions
+
+* [Scope 3 Challenge — Carbon3 Registry](https://github.com/co3org/Scope3-Challenge) - Verified Scope 3 disclosures from 1,391 companies across 35 sectors (sustainability reports 2022–2025), with API access at `demo.carbon3.net/api/emissions-registry`. Accompanying knowledge base explains the methodology differences that make raw corporate GHG disclosures hard to compare directly.
+
 ## Open Source Organisations
 
 * [Open Climate Fix](https://github.com/openclimatefix)


### PR DESCRIPTION
## What this adds

A new **Corporate Emissions** subsection under Data Sets, containing [Scope 3 Challenge / Carbon3 Registry](https://github.com/co3org/Scope3-Challenge).

## Why it fits

The current Data Sets section covers energy grids, residential consumption, and government environmental portals — but has no corporate-level GHG emissions data. Corporate Scope 3 disclosures are a distinct and increasingly important data domain, driven by CSRD, ISSB S2, and SBTi requirements.

## What the resource provides

**Data:** Verified Scope 3 disclosures from 1,391 companies across 35 sectors (sustainability reports 2022–2025), accessible via the Carbon3 Emissions Registry API at `demo.carbon3.net/api/emissions-registry`.

**Methodology guide:** The accompanying knowledge base explains the methodology differences (spend-based vs. hybrid vs. primary data; different emission factor databases; category boundary choices) that make raw corporate GHG disclosures hard to compare directly without understanding the context. This is essential for any data work with corporate emissions datasets.

The combination of dataset + methodology documentation makes this more useful to data practitioners than a bare API link would be.